### PR TITLE
fix(ui): Ensure Start Menu context menu actions execute on click

### DIFF
--- a/window/components/ContextMenu.tsx
+++ b/window/components/ContextMenu.tsx
@@ -40,8 +40,9 @@ const ContextMenu: React.FC<ContextMenuProps> = ({x, y, items, onClose}) => {
       style={{top: finalY, left: finalX}}
       className="fixed bg-black/80 backdrop-blur-xl border border-zinc-700 rounded-md shadow-lg py-1.5 w-48 text-sm text-zinc-100 z-[60] animate-fade-in-fast"
       onClick={e => {
-        e.stopPropagation(); // Prevent clicks inside menu from bubbling up to a dismiss handler
-        onClose(); // Close on any item click
+        // Prevent clicks inside menu from bubbling up to a dismiss handler
+        // that would close the menu, e.g., the one on the Start Menu container.
+        e.stopPropagation();
       }}
       onContextMenu={e => e.preventDefault()} // Prevent native context menu on our custom one
     >
@@ -52,7 +53,10 @@ const ContextMenu: React.FC<ContextMenuProps> = ({x, y, items, onClose}) => {
         return (
           <button
             key={index}
-            onClick={item.onClick}
+            onClick={() => {
+              item.onClick();
+              onClose();
+            }}
             disabled={item.disabled}
             className="w-full text-left px-3 py-1.5 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-sm flex items-center"
           >


### PR DESCRIPTION
The context menu in the Start Menu was not executing actions when items were clicked. This was caused by an event handling conflict in the `ContextMenu` component.

The component's main container had an `onClick` handler that called `onClose()` immediately, which would unmount the component before the clicked item's own `onClick` handler had a chance to fire.

This change resolves the issue by modifying the event handlers within `ContextMenu.tsx`:
- The container's `onClick` now only stops event propagation.
- The individual item buttons now call their specific action first, and then call `onClose()` to dismiss the menu.

This ensures that actions are always executed upon clicking a context menu item.