### PR TITLE
fix(ui): Fix Start Menu context menu 'Open' action

### DIFF
--- a/window/components/ContextMenu.tsx
+++ b/window/components/ContextMenu.tsx
@@ -40,8 +40,9 @@ const ContextMenu: React.FC<ContextMenuProps> = ({x, y, items, onClose}) => {
       style={{top: finalY, left: finalX}}
       className="fixed bg-black/80 backdrop-blur-xl border border-zinc-700 rounded-md shadow-lg py-1.5 w-48 text-sm text-zinc-100 z-[60] animate-fade-in-fast"
       onClick={e => {
-        e.stopPropagation(); // Prevent clicks inside menu from bubbling up to a dismiss handler
-        onClose(); // Close on any item click
+        // Prevent clicks inside menu from bubbling up to a dismiss handler
+        // that would close the menu, e.g., the one on the Start Menu container.
+        e.stopPropagation();
       }}
       onContextMenu={e => e.preventDefault()} // Prevent native context menu on our custom one
     >
@@ -52,7 +53,10 @@ const ContextMenu: React.FC<ContextMenuProps> = ({x, y, items, onClose}) => {
         return (
           <button
             key={index}
-            onClick={item.onClick}
+            onClick={() => {
+              item.onClick();
+              onClose();
+            }}
             disabled={item.disabled}
             className="w-full text-left px-3 py-1.5 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-sm flex items-center"
           >

--- a/window/components/StartMenu.tsx
+++ b/window/components/StartMenu.tsx
@@ -55,7 +55,14 @@ const StartMenu: React.FC<StartMenuProps> = ({onOpenApp, onClose}) => {
     e.stopPropagation();
 
     const menuItems: ContextMenuItem[] = [
-      {type: 'item', label: 'Open', onClick: () => onOpenApp(app)},
+      {
+        type: 'item',
+        label: 'Open',
+        onClick: () => {
+          onOpenApp(app);
+          onClose();
+        },
+      },
       {type: 'separator'},
       {type: 'item', label: 'Copy', onClick: () => {}},
       {type: 'item', label: 'Cut', onClick: () => {}},


### PR DESCRIPTION
This commit fixes the 'Open' action in the Start Menu's right-click context menu, ensuring it functions correctly. It also preserves the non-functional state of other menu items as per user requirements.

There were two issues preventing the 'Open' action from working:

1.  **Event Conflict:** An event race condition in `ContextMenu.tsx` caused the menu to close before the `onClick` action could be processed. This was fixed by modifying the event handlers to ensure the action executes before the menu closes.

2.  **Missing `onClose` call:** The 'Open' action did not close the main Start Menu after opening an app, which was inconsistent with the left-click behavior. This was fixed by adding the `onClose` call to the 'Open' item's `onClick` handler in `StartMenu.tsx`.

This commit also retains the simplified, static context menu from the previous attempt, as the user confirmed this was the correct approach to resolve the underlying complexity and performance issues.