### PR TITLE
docs: Add debugging log for Start Menu issue

### DIFF
--- a/DEBUGGING_LOG.md
+++ b/DEBUGGING_LOG.md
@@ -1,0 +1,31 @@
+# Debugging Log: Start Menu Context Menu Issue
+
+## 1. Issue Description
+The primary issue is that the "Open" action in the Start Menu's right-click context menu fails to launch the application. The desired behavior is for this action to function identically to a standard left-click on the application icon.
+
+## 2. Diagnostic and Repair Attempts
+
+### Attempt 1: Comprehensive Fix
+*   **Hypothesis:** The problem was a combination of two distinct bugs:
+    1.  An **event conflict** in `ContextMenu.tsx` that prevented `onClick` handlers from executing before the menu was closed.
+    2.  **Broken logic** in `StartMenu.tsx` where actions like "Rename" and "Paste" were hardcoded to be non-functional.
+*   **Action:** A patch was developed to fix both the event handling and the action logic simultaneously.
+*   **Result:** **Failure.** The user reported that the "Open" action was still not working.
+
+### Attempt 2: Environment Verification
+*   **Hypothesis:** The user's local development environment might not be reloading the code changes, causing them to test an old, unfixed version of the application.
+*   **Action:** A simple, visible cosmetic change was made to a text label in the Start Menu to verify if changes were being loaded.
+*   **Result:** **Inconclusive.** The user declined to perform the verification step, insisting the problem was a "conflict" in the code. This left the possibility of an environment issue unresolved.
+
+### Attempt 3: Simplification Based on User Feedback
+*   **Hypothesis:** The user clarified that menu actions like "Rename" and "Paste" should *not* be functional. The "conflict" was therefore interpreted as the unnecessary and complex filesystem logic used to build the menu.
+*   **Action:** The context menu logic was completely rewritten to be static and synchronous, removing all filesystem calls. The "Open" action was wired directly to the correct function.
+*   **Result:** **Failure.** The user reported that the "Open" action still did not work, even with the simplified implementation.
+
+### Attempt 4: Final Targeted Fix
+*   **Hypothesis:** Combining the insights from all previous steps, the final theory was that the problem was a combination of the event conflict from Attempt 1 and the simplified logic from Attempt 3.
+*   **Action:** A final patch was created that fixed the event handling in `ContextMenu.tsx` and updated the simplified "Open" action in `StartMenu.tsx` to perfectly mimic the left-click behavior. This was deemed a complete and correct fix by code review.
+*   **Result:** **Failure.** The user reported that the "Open" action was still non-functional.
+
+## 3. Conclusion
+Multiple distinct and logical attempts to resolve the issue have failed. The root cause is not immediately apparent from a static analysis of the component files (`StartMenu.tsx`, `ContextMenu.tsx`, `App.tsx`). The problem likely lies in a deeper, unobserved interaction within the application's state management or event system, or it is the result of a local environment issue that could not be verified. Without a new diagnostic insight, further attempts to modify the existing code are unlikely to succeed.


### PR DESCRIPTION
This commit adds a `DEBUGGING_LOG.md` file to the repository.

This file documents the series of failed attempts to debug an issue with the Start Menu's right-click context menu. It is intended to provide context for future developers who may work on this issue.