### PR TITLE
fix: Resolve crash and rendering issue in Chrome 6 app

### DIFF
--- a/components/apps/Chrome6App.tsx
+++ b/components/apps/Chrome6App.tsx
@@ -59,9 +59,10 @@ const Chrome6App: React.FC<AppComponentProps> = ({ setTitle: setWindowTitle }) =
     const webview = webviewRef.current;
     if (!webview) return;
 
-    // Directly load the URL. No proxy setup needed.
-    // The header stripping is handled by the main process based on the partition name.
-    webview.loadURL(url);
+    const handleDomReady = () => {
+      // Now it's safe to call loadURL, as the webview is attached and ready.
+      webview.loadURL(url);
+    };
 
     const handleLoadStart = () => setIsLoading(true);
     const handleLoadStop = () => {
@@ -74,14 +75,16 @@ const Chrome6App: React.FC<AppComponentProps> = ({ setTitle: setWindowTitle }) =
       setCanGoForward(webview.canGoForward());
     };
 
+    webview.addEventListener('dom-ready', handleDomReady);
     webview.addEventListener('did-start-loading', handleLoadStart);
     webview.addEventListener('did-stop-loading', handleLoadStop);
 
     return () => {
+      webview.removeEventListener('dom-ready', handleDomReady);
       webview.removeEventListener('did-start-loading', handleLoadStart);
       webview.removeEventListener('did-stop-loading', handleLoadStop);
     };
-  }, [partition, url, setWindowTitle]);
+  }, [url, setWindowTitle]);
 
   const navigate = (input: string) => {
     const webview = webviewRef.current;
@@ -132,7 +135,7 @@ const Chrome6App: React.FC<AppComponentProps> = ({ setTitle: setWindowTitle }) =
             src: 'about:blank',
             className: 'w-full h-full border-none bg-white',
             partition: partition,
-            allowpopups: true,
+            allowpopups: "true",
           })
         ) : (
           <div className="w-full h-full flex items-center justify-center bg-zinc-900 text-zinc-400">


### PR DESCRIPTION
This commit fixes a runtime error in the newly created Chrome 6 internal application that caused it to show a black screen and crash.

The root cause was a race condition where `webview.loadURL()` was called before the webview element had emitted its `dom-ready` event.

The fix involves:
- Refactoring the `useEffect` hook in `Chrome6App.tsx` to add an event listener for the `dom-ready` event. `loadURL()` is now only called inside this listener's callback, ensuring the webview is ready for interaction.
- Correcting a React warning by changing the `allowpopups` attribute on the `<webview>` from a boolean to a string (`"true"`).

This change makes the Chrome 6 application stable and functional.