### PR TITLE
fix(chrome6): Final fix for navigation loop

### DIFF
--- a/components/apps/Chrome6App.tsx
+++ b/components/apps/Chrome6App.tsx
@@ -52,6 +52,7 @@ const Chrome6App: React.FC<AppComponentProps> = ({ setTitle: setWindowTitle }) =
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
   const webviewRef = useRef<WebViewElement | null>(null);
+  const hasLoadedInitialUrl = useRef(false);
   const partition = 'persist:chrome6'; // Use a unique partition for Chrome 6
 
   useEffect(() => {
@@ -61,10 +62,10 @@ const Chrome6App: React.FC<AppComponentProps> = ({ setTitle: setWindowTitle }) =
     const initialUrl = 'https://www.google.com/search?q=what+is+my+user+agent';
 
     const handleDomReady = () => {
-      // This listener should only ever fire once to load the initial URL.
-      webview.loadURL(initialUrl);
-      // It's crucial to remove it so it doesn't hijack subsequent navigations.
-      webview.removeEventListener('dom-ready', handleDomReady);
+      if (!hasLoadedInitialUrl.current) {
+        hasLoadedInitialUrl.current = true;
+        webview.loadURL(initialUrl);
+      }
     };
 
     const handleLoadStart = () => setIsLoading(true);


### PR DESCRIPTION
This commit resolves a subtle bug in the Chrome 6 app caused by React's Strict Mode double-invoking the useEffect hook. This led to an extra event listener that would hijack user navigation and reload the initial URL.

The fix implements a `useRef` flag (`hasLoadedInitialUrl`) to ensure that the logic for loading the initial URL is executed only once, regardless of how many times the effect is mounted or re-rendered. This makes the component's effect idempotent and robust.

This change definitively solves the flickering and navigation issues reported by the user.