### PR TITLE
fix(chrome6): Ensure unique tab IDs

### DIFF
--- a/components/apps/Chrome6App.tsx
+++ b/components/apps/Chrome6App.tsx
@@ -65,6 +65,7 @@ interface Tab {
 const Chrome6App: React.FC<AppComponentProps> = ({ setTitle: setWindowTitle }) => {
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  const nextTabId = useRef(0);
 
   // A ref to hold the webview elements for easy access
   const webviewRefs = useRef<{[key: string]: WebViewElement}>({});
@@ -72,7 +73,7 @@ const Chrome6App: React.FC<AppComponentProps> = ({ setTitle: setWindowTitle }) =
 
   // Function to create a new tab
   const createNewTab = (url = 'https://www.google.com/search?q=what+is+my+user+agent') => {
-    const newTabId = `tab-${Date.now()}`;
+    const newTabId = `tab-${nextTabId.current++}`;
     const newTab: Tab = {
       id: newTabId,
       url: url,


### PR DESCRIPTION
This commit resolves a critical rendering bug in the Chrome 6 tabbed browser caused by the generation of non-unique keys for new tabs.

The previous method of using `Date.now()` to generate tab IDs was not reliable, especially in React's Strict Mode, leading to duplicate keys and unpredictable rendering behavior.

The fix replaces the `Date.now()` implementation with a `useRef` counter. This guarantees that every new tab receives a unique ID for the component's lifecycle, resolving the "Encountered two children with the same key" warning and stabilizing the UI.