### PR TITLE
feat(chrome7): Add CSP header to proxy

### DIFF
--- a/main/api.js
+++ b/main/api.js
@@ -46,6 +46,10 @@ function startApiServer() {
       const response = await fetch(url);
       const text = await response.text();
 
+      // Set CSP to prevent frame-busting.
+      // 'self' allows the content to be framed by our own origin.
+      res.setHeader('Content-Security-Policy', "frame-ancestors 'self';");
+
       // For now, just send the raw HTML.
       // In the future, we would parse and rewrite links here.
       res.send(text);


### PR DESCRIPTION
This commit enhances the Chrome 7 web proxy by adding a Content-Security-Policy (CSP) header to the backend response.

This prevents websites with "frame-busting" scripts (like Google) from breaking out of the iframe and taking over the main application window. The `frame-ancestors 'self'` directive ensures that the proxied content can only be framed by the application itself.

This makes the Chrome 7 prototype more robust and usable for a wider range of websites.