### PR TITLE
feat: Restore DevTools and allow localhost proxy

### DIFF
--- a/main/api.js
+++ b/main/api.js
@@ -43,11 +43,6 @@ function startApiServer() {
         return res.status(400).send('Invalid URL protocol.');
       }
 
-      // Security check to prevent proxying local resources
-      if (parsedUrl.hostname === 'localhost' || parsedUrl.hostname === '127.0.0.1') {
-        return res.status(403).send('Proxying local resources is not allowed.');
-      }
-
       const response = await fetch(url);
       const text = await response.text();
 

--- a/main/index.js
+++ b/main/index.js
@@ -30,11 +30,13 @@ function createWindow() {
 
   if (isDev) {
     mainWindow.loadURL('http://localhost:5173');
-    mainWindow.webContents.openDevTools();
   } else {
     // Correct path to production build, going up one level from 'main'
     mainWindow.loadFile(path.join(__dirname, '..', 'dist', 'index.html'));
   }
+
+  // Always open DevTools as requested
+  mainWindow.webContents.openDevTools();
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
This commit implements two final user requests:
1.  The developer console (DevTools) is now configured to open automatically on application startup for easier debugging. The `if (isDev)` check has been removed to make this behavior unconditional.
2.  The security check in the Chrome 7 web proxy that blocked requests to `localhost` has been removed. This re-enables the "system-in-a-system" recursive embedding feature as requested by the user.